### PR TITLE
Add CSS/JS frontend files

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+HOLESKY_RPC_URL=https://your-holesky-rpc-url
+PRIVATE_KEY=your-private-key

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,38 @@
-# Codex
+# Codex Token on Holesky
+
+This project contains a simple ERC20 token called **Codex** (`CDX`) and example code to deploy it to the Ethereum Holesky testnet using Hardhat. A minimal web page demonstrates how to read a connected user's balance via MetaMask.
+
+## Directory Overview
+
+- `contracts/` – Solidity smart contracts
+- `scripts/` – Hardhat deployment script
+- `frontend/` – Example HTML, CSS and JavaScript frontend
+- `hardhat.config.js` – Hardhat configuration
+- `package.json` – Node dependencies (Hardhat, ethers, OpenZeppelin)
+
+## Setup
+
+1. Install Node.js (v18+ recommended).
+2. Install dependencies:
+   ```bash
+   npm install
+   ```
+3. Copy `.env.example` to `.env` and fill in `HOLESKY_RPC_URL` and `PRIVATE_KEY` (or edit `hardhat.config.js` directly).
+4. Compile contracts:
+   ```bash
+   npm run compile
+   ```
+5. Deploy to Holesky:
+   ```bash
+   npm run deploy
+   ```
+   The script prints the deployed token address.
+
+## Frontend Usage
+
+Open `frontend/index.html` in a browser with MetaMask installed. Enter the deployed token address in `app.js` (replace `0xYOUR_TOKEN_ADDRESS`) and refresh. Click **Connect Wallet** to see the connected account's CDX balance.
+
+## Notes
+
+- The provided configuration includes placeholders for RPC URL and private key. Never commit real private keys.
+- Holesky is an Ethereum testnet; tokens deployed there have no real-world value.

--- a/contracts/CodexToken.sol
+++ b/contracts/CodexToken.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract CodexToken is ERC20 {
+    constructor(uint256 initialSupply) ERC20("Codex", "CDX") {
+        _mint(msg.sender, initialSupply);
+    }
+}

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,0 +1,28 @@
+const tokenAddress = "0xYOUR_TOKEN_ADDRESS"; // replace after deployment
+const abi = [
+  "function balanceOf(address) view returns (uint256)",
+  "function transfer(address to, uint amount) returns (bool)"
+];
+let provider;
+let signer;
+let token;
+
+async function connect() {
+  if (window.ethereum) {
+    provider = new ethers.BrowserProvider(window.ethereum);
+    await provider.send("eth_requestAccounts", []);
+    signer = await provider.getSigner();
+    token = new ethers.Contract(tokenAddress, abi, signer);
+    updateBalance();
+  } else {
+    alert("Please install MetaMask!");
+  }
+}
+
+async function updateBalance() {
+  const addr = await signer.getAddress();
+  const balance = await token.balanceOf(addr);
+  document.getElementById("balance").innerText = ethers.formatUnits(balance, 18);
+}
+
+document.getElementById("connect").onclick = connect;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Codex Token</title>
+  <link rel="stylesheet" href="style.css">
+  <script src="https://cdn.jsdelivr.net/npm/ethers@6.7.0/dist/ethers.min.js"></script>
+  <script defer src="app.js"></script>
+</head>
+<body>
+  <h1>Codex Token DApp</h1>
+  <button id="connect">Connect Wallet</button>
+  <p>Your balance: <span id="balance">0</span> CDX</p>
+</body>
+</html>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1,0 +1,3 @@
+body { font-family: Arial, sans-serif; margin: 2rem; }
+button { padding: 0.5rem 1rem; font-size: 1rem; }
+#balance { font-weight: bold; }

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -1,0 +1,13 @@
+require("@nomiclabs/hardhat-ethers");
+require('dotenv').config();
+
+/** @type import('hardhat/config').HardhatUserConfig */
+module.exports = {
+  solidity: "0.8.20",
+  networks: {
+    holesky: {
+      url: process.env.HOLESKY_RPC_URL || "",
+      accounts: process.env.PRIVATE_KEY ? [process.env.PRIVATE_KEY] : []
+    }
+  }
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "codex",
+  "version": "1.0.0",
+  "description": "Sample Holesky token project",
+  "main": "hardhat.config.js",
+  "scripts": {
+    "compile": "npx hardhat compile",
+    "deploy": "npx hardhat run scripts/deploy.js --network holesky"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "@nomiclabs/hardhat-ethers": "^2.3.0",
+    "@openzeppelin/contracts": "^5.0.0",
+    "ethers": "^6.7.0",
+    "hardhat": "^2.22.0",
+    "dotenv": "^16.3.1"
+  }
+}

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -1,0 +1,14 @@
+const { ethers } = require("hardhat");
+
+async function main() {
+  const initialSupply = ethers.parseUnits("1000000", 18); // 1 million tokens
+  const Token = await ethers.getContractFactory("CodexToken");
+  const token = await Token.deploy(initialSupply);
+  await token.deployed();
+  console.log("CodexToken deployed to:", token.address);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- refactor frontend to separate CSS and JS
- adjust deploy script for ethers v6 parseUnits
- document new frontend files in README

## Testing
- `npm install` *(failed: no output)*
- `npx hardhat compile` *(failed: no output)*
- `git status --short`