### PR TITLE
Switch to @nomicfoundation/hardhat-ethers

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -1,4 +1,4 @@
-require("@nomiclabs/hardhat-ethers");
+require("@nomicfoundation/hardhat-ethers");
 require('dotenv').config();
 
 /** @type import('hardhat/config').HardhatUserConfig */

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@nomiclabs/hardhat-ethers": "^2.3.0",
+    "@nomicfoundation/hardhat-ethers": "^2.3.0",
     "@openzeppelin/contracts": "^5.0.0",
     "ethers": "^6.7.0",
     "hardhat": "^2.22.0",

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -1,10 +1,10 @@
 const { ethers } = require("hardhat");
 
 async function main() {
-  const initialSupply = ethers.utils.parseUnits("1000000", 18); // 1 million tokens
+  const initialSupply = ethers.parseUnits("1000000", 18); // 1 million tokens
   const Token = await ethers.getContractFactory("CodexToken");
   const token = await Token.deploy(initialSupply);
-  await token.deployed();
+  await token.waitForDeployment();
   console.log("CodexToken deployed to:", token.address);
 }
 


### PR DESCRIPTION
## Summary
- update hardhat plugin dependency to `@nomicfoundation/hardhat-ethers`
- adapt `hardhat.config.js` import
- migrate deployment script to Ethers v6

## Testing
- `npm install` *(fails: EHOSTUNREACH)*
- `npx hardhat run scripts/deploy.js --network hardhat` *(fails: EHOSTUNREACH)*